### PR TITLE
fix: pass top level state as props to trainings

### DIFF
--- a/src/authed-app.tsx
+++ b/src/authed-app.tsx
@@ -58,6 +58,8 @@ const AuthedApp = (): JSX.Element => {
     <div className="authed">
       {trainings ? (
         <MemoizedTrainings
+          mode={mode}
+          dispatch={dispatch}
           trainings={trainings}
           textAreaRef={textAreaRef}
           handleSetEditMode={handleSetEditMode}

--- a/src/trainings.tsx
+++ b/src/trainings.tsx
@@ -1,6 +1,5 @@
 import { Dispatch, Fragment, memo, useMemo } from "react";
 import { HandleSetEditModeParams } from "./authed-app";
-import { useTopLevelState } from "./context";
 import { getLatestPercentageChanges } from "./get-latest-percentage-change";
 import {
   createDateFormat,
@@ -10,26 +9,28 @@ import { serializeTraining } from "./serialize-training";
 import { Action } from "./state-reducer";
 import "./styles/trainings.css";
 import { TrainingTableWithButtons } from "./training-table-with-buttons";
-import { Training } from "./types";
+import { Mode, Training } from "./types";
 
 interface TrainingsProps {
+  readonly mode: Mode;
+  readonly dispatch: Dispatch<Action>;
   readonly trainings: Training[];
+  readonly textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
   readonly handleSetEditMode: ({
     id,
     trainings,
     dispatch,
     textAreaRef,
   }: HandleSetEditModeParams) => void;
-  readonly textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
 }
 
 export const Trainings = ({
+  mode,
+  dispatch,
   trainings,
   textAreaRef,
   handleSetEditMode,
 }: TrainingsProps): JSX.Element | null => {
-  const [{ mode }, dispatch] = useTopLevelState();
-
   const groupedTrainings = useMemo(
     // Displaying the list with flex-direction: 'column-reverse' is an
     // optimisation which could be made here instead of this.


### PR DESCRIPTION
Because consuming a context makes a component rerender if the context changes, we have to provide the top level state as props to the trainings component to ensure that it doesn't rerender if the text input (and therefore the top level state) changes.