### PR TITLE
feat: alternative input layer

### DIFF
--- a/src/bottom-bar.tsx
+++ b/src/bottom-bar.tsx
@@ -10,7 +10,7 @@ import { ImInfo } from "react-icons/im";
 import { IoMdAdd, IoMdClose } from "react-icons/io";
 import { IoCheckmarkSharp } from "react-icons/io5";
 import { addTraining } from "./add-training";
-import { useAuth, useTopLevelState } from "./context";
+import { useAuth, useIsMobile, useTopLevelState } from "./context";
 import { editTraining } from "./edit-training";
 import { Input } from "./input";
 import { parse } from "./parser";
@@ -33,6 +33,7 @@ export function BottomBar({
   setShowFormatInfo,
 }: BottomBarProps): JSX.Element | null {
   const { logout } = useAuth();
+  const isMobile = useIsMobile();
   const bottomBarRef = useRef(null);
   const bottomCTAsHeight = useBottomCTAsHeight();
 
@@ -70,6 +71,7 @@ export function BottomBar({
   return (
     <footer
       ref={bottomBarRef}
+      style={{ height: isMobile ? "84%" : "34%" }}
       className={`bottom-bar ${showBottomBar ? "" : "closed"}`}
     >
       <div className="input-btn-container input-top-container">
@@ -212,11 +214,10 @@ const handleEdit = ({
 };
 
 const useBottomCTAsHeight = (): number => {
+  const isMobile = useIsMobile();
   const changedHeightRef = useRef(false);
 
-  const [bottomCTAsHeight, setBottomCTAsHeight] = useState(
-    visualViewport?.height || 0
-  );
+  const [bottomCTAsHeight, setBottomCTAsHeight] = useState(BOTTOM_CTAS_MARGIN);
 
   const resizeHandler = useCallback(() => {
     if (changedHeightRef.current || !visualViewport) {
@@ -231,10 +232,14 @@ const useBottomCTAsHeight = (): number => {
   }, []);
 
   useLayoutEffect(() => {
+    if (!isMobile) {
+      return;
+    }
+
     visualViewport?.addEventListener("resize", resizeHandler);
 
     return () => visualViewport?.removeEventListener("resize", resizeHandler);
-  }, [resizeHandler]);
+  }, [resizeHandler, isMobile]);
 
   return bottomCTAsHeight;
 };

--- a/src/bottom-bar.tsx
+++ b/src/bottom-bar.tsx
@@ -71,7 +71,7 @@ export function BottomBar({
   return (
     <footer
       ref={bottomBarRef}
-      style={{ height: isMobile ? "84%" : "34%" }}
+      style={{ height: isMobile ? "85%" : "35%" }}
       className={`bottom-bar ${showBottomBar ? "" : "closed"}`}
     >
       <div className="input-btn-container input-top-container">

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -25,7 +25,7 @@ export const Input = ({
   }, [currentInput, textAreaRef]);
 
   const autoGrow = (element: HTMLTextAreaElement) => {
-    const minHeight = 80;
+    const minHeight = 100;
     // Reset height
     element.style.height = `${minHeight}px`;
     element.style.height = `${element.scrollHeight}px`;
@@ -35,8 +35,8 @@ export const Input = ({
     <>
       <div className="input-wrapper">
         <textarea
-          autoComplete="on"
-          placeholder="Squats @80kg 8/8/8"
+          autoComplete="off"
+          placeholder="Squats @80kg 8/8/8 ..."
           onChange={(event) =>
             dispatch({
               type: "set-input",

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -25,7 +25,7 @@ export const Input = ({
   }, [currentInput, textAreaRef]);
 
   const autoGrow = (element: HTMLTextAreaElement) => {
-    const minHeight = 100;
+    const minHeight = 130;
     // Reset height
     element.style.height = `${minHeight}px`;
     element.style.height = `${element.scrollHeight}px`;

--- a/src/styles/bottom-bar.css
+++ b/src/styles/bottom-bar.css
@@ -6,24 +6,27 @@
   position: fixed;
   bottom: 0;
   width: 100%;
+  height: 84%;
   background-color: var(--background-secondary);
   box-shadow: var(--box-shadow-top);
   z-index: 1;
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
-  transform: translateY(0);
-  transition: transform 0.2s ease;
+  transition: opacity 0.2s ease-out;
   border: 1px solid var(--border-primary);
+  opacity: 1;
 }
 
 .closed {
-  transform: translateY(100%);
+  opacity: 0;
   padding: 0;
+  pointer-events: none;
 }
 
 .input-btn-container {
   width: min(450px, 92%);
   display: flex;
+  align-items: center;
   justify-content: space-between;
 }
 
@@ -32,8 +35,8 @@
 }
 
 .input-bottom-container {
-  margin-bottom: 16px;
-  height: 22px;
+  height: 28px;
+  margin-top: 24px;
 }
 
 .btn-info {
@@ -54,18 +57,18 @@
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
 }
 
 .btn-confirm::before {
   content: "";
   position: absolute;
-  top: -4px;
-  left: -4px;
-  width: calc(100% + 8px);
-  height: calc(100% + 8px);
+  top: -5px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 10px);
   border-radius: 50%;
-  background: var(--hover-circle);
+  border: 0.8px solid var(--border-secondary);
   z-index: -1;
 }

--- a/src/styles/bottom-bar.css
+++ b/src/styles/bottom-bar.css
@@ -6,7 +6,6 @@
   position: fixed;
   bottom: 0;
   width: 100%;
-  height: 84%;
   background-color: var(--background-secondary);
   box-shadow: var(--box-shadow-top);
   z-index: 1;

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -2,19 +2,19 @@
   position: relative;
   width: min(450px, 93%);
   border-top: 0.8px solid var(--border-primary);
+  border-bottom: 0.8px solid var(--border-primary);
 }
 
 textarea {
   line-height: 1.25;
   color: var(--text-primary);
   width: 100%;
-  height: 50px;
-  max-height: 180px;
+  height: 100px;
+  max-height: 175px;
   background: var(--background-secondary);
   border: none;
-  border-radius: 10px;
   outline: none;
-  padding: 8px 4px;
+  padding: 12px 4px;
   resize: none;
 }
 

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -9,7 +9,7 @@ textarea {
   line-height: 1.25;
   color: var(--text-primary);
   width: 100%;
-  height: 100px;
+  height: 130px;
   max-height: 175px;
   background: var(--background-secondary);
   border: none;

--- a/src/styles/layer.css
+++ b/src/styles/layer.css
@@ -20,7 +20,7 @@
 .muted-background {
   opacity: 0;
   background-color: var(--background-muted);
-  transition: opacity 0.1s ease;
+  transition: opacity 0.15s ease;
   z-index: 1;
 }
 

--- a/src/styles/suggestion.css
+++ b/src/styles/suggestion.css
@@ -1,4 +1,8 @@
 .suggestion {
-  padding: 4px 0;
+  font-size: 14px;
+  padding: 3px 8px;
+  border-radius: 26px;
+  align-items: center;
   color: var(--color-progress);
+  border: 0.8px solid var(--color-progress);
 }


### PR DESCRIPTION
In order to not trigger a layout shift because of the weird quirks of having a bottom bar with an input element on mobile devices, we place the input elemnt further to the top so the shift does not get triggered. This also gives us space to add more functionality to the input in the future.

For reference of the underlying problem:
https://github.com/bramus/viewport-resize-behavior/blob/main/explainer.md#the-icb